### PR TITLE
Remove obsolete code using obsolete VERSION gvar

### DIFF
--- a/gap/hom.gd
+++ b/gap/hom.gd
@@ -37,13 +37,3 @@ DeclareProperty( "IsFromAffineCrystGroupToFpGroup",
 ##
 DeclareProperty( "IsFromAffineCrystGroupToPcpGroup", 
                                              IsGroupGeneralMappingByImages );
-
-#############################################################################
-##
-#A  MappingGeneratorsImages - for compatibility with GAP 4.2 and GAP 4.1
-##
-if not CompareVersionNumbers( VERSION, "4.3" ) then
-    if not IsBound( MappingGeneratorsImages ) then
-        DeclareAttribute( "MappingGeneratorsImages", IsGeneralMapping );
-    fi;
-fi;


### PR DESCRIPTION
Since cryst requires GAP >= 4.5 anyway, there is no need to keep this
code for compatibility with GAP 4.2 and GAP 4.1.