### PR TITLE
renaming PreImagesRepresentative as NC version

### DIFF
--- a/gap/cryst.gi
+++ b/gap/cryst.gi
@@ -502,7 +502,7 @@ function( m, S )
         return false;
     fi;
 
-    mm := PreImagesRepresentative( PointHomomorphism( S ), mm );
+    mm := PreImagesRepresentativeNC( PointHomomorphism( S ), mm );
     if IsAffineCrystGroupOnRight( S ) then
         if not IsAffineMatrixOnRight( m ) then
             return false;

--- a/gap/cryst2.gi
+++ b/gap/cryst2.gi
@@ -303,7 +303,7 @@ function( S, rep )
     T := ReducedLatticeBasis( TranslationBasis( S )*m );
 
     mm  := CanonicalRightCosetElement( P, m );
-    res := PreImagesRepresentative( PointHomomorphism( S ), mm*m^-1 ) * rep;
+    res := PreImagesRepresentativeNC( PointHomomorphism( S ), mm*m^-1 ) * rep;
     res := MutableCopyMat( res );
     res[d+1]{[1..d]} := VectorModL( res[d+1]{[1..d]}, T );
     return res;
@@ -322,7 +322,7 @@ function( S, rep )
     T := ReducedLatticeBasis( TranslationBasis( S )*m );
 
     mm  := CanonicalRightCosetElement( P, m );
-    res := PreImagesRepresentative( PointHomomorphism( S ), mm*m^-1 ) * rep;
+    res := PreImagesRepresentativeNC( PointHomomorphism( S ), mm*m^-1 ) * rep;
     res := MutableCopyMat( res );
     res{[1..d]}[d+1] := VectorModL( res{[1..d]}[d+1], T );
     return res;
@@ -352,9 +352,9 @@ function( G1, G2 )
     L  := UnionModule( T1, T2 );
 
     gen  := GeneratorsOfGroup( P );
-    gen1 := List( gen, x -> PreImagesRepresentative( 
+    gen1 := List( gen, x -> PreImagesRepresentativeNC( 
                                    PointHomomorphism( G1 ), x) );
-    gen2 := List( gen, x -> PreImagesRepresentative( 
+    gen2 := List( gen, x -> PreImagesRepresentativeNC( 
                                    PointHomomorphism( G2 ), x)^-1 );
 
     orb := [ MutableMatrix( One( G1 ) ) ];
@@ -384,10 +384,10 @@ function( G1, G2 )
     # determine the lift of stb
     new := [];
     for g in GeneratorsOfGroup( stb ) do
-        g1 := PreImagesRepresentative( PointHomomorphism( G1 ), g );
+        g1 := PreImagesRepresentativeNC( PointHomomorphism( G1 ), g );
         g1 := AffMatMutableTrans( g1 );
         if Length(T1) > 0 then
-            g2 := PreImagesRepresentative( PointHomomorphism( G2 ), g );
+            g2 := PreImagesRepresentativeNC( PointHomomorphism( G2 ), g );
             t1 := g1[d+1]{[1..d]};
             t2 := g2[d+1]{[1..d]};
             s  := IntSolutionMat( Concatenation( T1, -T2 ), t2-t1 ); 
@@ -538,7 +538,7 @@ CentralizerAffineCrystGroup := function ( G, obj )
     fi; 
 
     gen := List( GeneratorsOfGroup( P ), 
-                 x -> PreImagesRepresentative( PointHomomorphism( G ), x ) );
+                 x -> PreImagesRepresentativeNC( PointHomomorphism( G ), x ) );
 
     # if G is finite
     if e = 0 then
@@ -782,7 +782,7 @@ function( S )
     T := TranslationBasis( S );
     N := NormalizerPointGroupInGLnZ( P ); 
     Pgens := GeneratorsOfGroup( P );
-    Sgens := List( Pgens, x -> PreImagesRepresentative( H, x ) );
+    Sgens := List( Pgens, x -> PreImagesRepresentativeNC( H, x ) );
 
     # we work in a standard representation
     if not IsStandardAffineCrystGroup( S ) then
@@ -805,7 +805,7 @@ function( S )
         if m = mm then
             res := [ data[1], List( data[2]*g, FractionModOne ) ];
         else
-           m := AffMatMutableTrans( PreImagesRepresentative( hom, mm ) );
+           m := AffMatMutableTrans( PreImagesRepresentativeNC( hom, mm ) );
            m[d+1]{[1..d]} := List( m[d+1]{[1..d]}, FractionModOne );
            res := [ m, List( data[2]*g, FractionModOne ) ];
         fi;

--- a/gap/equiv.gi
+++ b/gap/equiv.gi
@@ -33,11 +33,11 @@ ConjugatorSpaceGroupsStdSamePG := function( S1, S2 )
     od;
 
     gen1 := List( GeneratorsOfGroup( P ), 
-            x -> PreImagesRepresentative( PointHomomorphism( S1 ), x ) );
+            x -> PreImagesRepresentativeNC( PointHomomorphism( S1 ), x ) );
     t1   := Concatenation( List( gen1, x -> x[d+1]{[1..d]} ) );
 
     gen2 := List( GeneratorsOfGroup( P ), 
-             x -> PreImagesRepresentative( PointHomomorphism( S2 ), x ) );
+             x -> PreImagesRepresentativeNC( PointHomomorphism( S2 ), x ) );
     t2   := Concatenation( List( gen2, x -> x[d+1]{[1..d]} ) );
 
     sol  := SolveInhomEquationsModZ( M, t1-t2, true )[1];
@@ -59,7 +59,7 @@ ConjugatorSpaceGroupsStdSamePG := function( S1, S2 )
                 Add( orb, img );
                 Add( rep, nn  );
                 gen1 := List( GeneratorsOfGroup( P ),
-                  x -> PreImagesRepresentative( PointHomomorphism( img ), x ) );
+                  x -> PreImagesRepresentativeNC( PointHomomorphism( img ), x ) );
                 n1 := nn{[1..d]}{[1..d]};
                 t1 := Concatenation( List( gen1, x -> x[d+1]{[1..d]}));
                 sol  := SolveInhomEquationsModZ( M, t1-t2, true )[1];

--- a/gap/fpgrp.gi
+++ b/gap/fpgrp.gi
@@ -30,7 +30,7 @@ function ( P )
         F    := Image( IsomorphismFpGroupByGenerators( N, gens ) );
     fi;
 
-    gensP := List( gens, x -> PreImagesRepresentative( mono, x ) );
+    gensP := List( gens, x -> PreImagesRepresentativeNC( mono, x ) );
     gensS := List( gens, x -> ImagesRepresentative( NiceToCryst( P ), x ) );
     gensF := GeneratorsOfGroup( F );
 

--- a/gap/hom.gi
+++ b/gap/hom.gi
@@ -22,9 +22,9 @@ end );
 
 #############################################################################
 ##
-#M  PreImagesRepresentative( <hom>, <elm> ) . . . . . . for PointHomomorphism
+#M  PreImagesRepresentativeNC( <hom>, <elm> ) . . . . . for PointHomomorphism
 ##
-InstallMethod( PreImagesRepresentative, FamRangeEqFamElm,
+InstallMethod( PreImagesRepresentativeNC, FamRangeEqFamElm,
         [ IsGroupGeneralMappingByImages and IsPointHomomorphism,
           IsMultiplicativeElementWithInverse ], 0,
     function( hom, elm )

--- a/gap/orbstab.gi
+++ b/gap/orbstab.gi
@@ -164,7 +164,7 @@ function( G, d, e, opr )
       local dim, gen, t1, sol;
       dim := DimensionOfMatrixGroup( P );
       gen := List( GeneratorsOfGroup( P ), 
-                   x -> PreImagesRepresentative( PointHomomorphism( U ), x ) );
+                 x -> PreImagesRepresentativeNC( PointHomomorphism( U ), x ) );
       t1  := Concatenation( List( gen, x -> x[dim+1]{[1..dim]} ) ) - t2;
       sol := IntSolutionMat( tr1, -t1 );
       if sol = fail then
@@ -203,7 +203,7 @@ function( G, d, e, opr )
         return fail;
     fi;
     r := r*r2;
-    R := PreImagesRepresentative( PointHomomorphism( G ), r );
+    R := PreImagesRepresentativeNC( PointHomomorphism( G ), r );
 
     dim := DimensionOfMatrixGroup( PG );
     gP := GeneratorsOfGroup( Pe );
@@ -218,7 +218,7 @@ function( G, d, e, opr )
     tr1 := List( TG, t -> Concatenation( List( gP, x -> t * ( One(Pe)-x ) ) ) );
     tr1 := Concatenation( tr1, M );
     tr2 := ReducedLatticeBasis( tr1 );
-    tt  := List( gP, x -> PreImagesRepresentative( PointHomomorphism(e), x ));
+    tt  := List( gP, x -> PreImagesRepresentativeNC( PointHomomorphism(e), x ));
     tt  := Concatenation( List( tt, x -> x[dim+1]{[1..dim]} ) );
 
     # is there a conjugating translation?
@@ -229,7 +229,7 @@ function( G, d, e, opr )
 
     # now we have to try the normalizer
     gN := Filtered( GeneratorsOfGroup( Normalizer(n, Pe) ), x -> not x in Pe );
-    gN := List( gN, x -> PreImagesRepresentative( PointHomomorphism(G), x ) );
+    gN := List( gN, x -> PreImagesRepresentativeNC( PointHomomorphism(G), x ) );
 
     orb := [ res ];
     rep := [ R ];
@@ -289,7 +289,7 @@ ConjugatingTranslation := function( G, gen, T )
         if not g in PointGroup( G ) then
             return fail;
         fi;
-        m := PreImagesRepresentative( PointHomomorphism( G ), g );
+        m := PreImagesRepresentativeNC( PointHomomorphism( G ), g );
         Append( b, -gen[i][d+1]{[1..d]} +  m[d+1]{[1..d]} );
         M{[1..lt]}{[1..d]+(i-1)*d} := T * (I - g);
         if lg > 0 then
@@ -335,7 +335,7 @@ function( G, H )
     d := DimensionOfMatrixGroup( P );
     I := IdentityMat( d );
     gens := List( GeneratorsOfGroup( P ), 
-                  x -> PreImagesRepresentative( PointHomomorphism( G ), x ) );
+                  x -> PreImagesRepresentativeNC( PointHomomorphism( G ), x ) );
 
     # stabilizer of translation conjugacy class of H
     TG  := TranslationBasis( G );

--- a/gap/pcpgrp.gi
+++ b/gap/pcpgrp.gi
@@ -26,8 +26,8 @@ function ( P )
     repr := IsomorphismPcpGroup( N );
     F    := Image( repr );
     gens := Igs( F );
-    prei := List( gens, x -> PreImagesRepresentative( repr, x ) );
-    prei := List( prei, x -> PreImagesRepresentative( mono, x ) );
+    prei := List( gens, x -> PreImagesRepresentativeNC( repr, x ) );
+    prei := List( prei, x -> PreImagesRepresentativeNC( mono, x ) );
 
     iso := GroupHomomorphismByImagesNC( P, F, prei, gens );
     SetMappingGeneratorsImages( iso, [ prei, gens ] );
@@ -56,7 +56,7 @@ function( S )
     # determine preimages
     F := Image( iso );
     gensF := Cgs(F);
-    gensN := List( gensF, x -> PreImagesRepresentative( iso, x ) );
+    gensN := List( gensF, x -> PreImagesRepresentativeNC( iso, x ) );
     matsP := List( gensN, x -> ImagesRepresentative( NiceToCryst( P ), x ) );
 
     # set up some variables
@@ -168,7 +168,7 @@ function(iso, elm)
     # get preimages
     F := Image(w);
     gensF := Cgs(F);
-    gensN := List(gensF, x -> PreImagesRepresentative(w, x));
+    gensN := List(gensF, x -> PreImagesRepresentativeNC(w, x));
     matsP := List(gensN, x -> ImagesRepresentative(l, x));
     
     # point group part
@@ -195,7 +195,7 @@ function(iso, elm)
     h := Cgs(H);
 
     # do some check
-    p := List(h, x -> PreImagesRepresentative(iso,x));
+    p := List(h, x -> PreImagesRepresentativeNC(iso,x));
     if MappedVector(exp, p) <> elm then Error("hier"); fi;
 
     return MappedVector(exp, h);

--- a/gap/zass.gi
+++ b/gap/zass.gi
@@ -240,7 +240,7 @@ CollectEquivExtensions := function( ll, nn, norm, grp )
             h :=GroupHomomorphismByImagesNC( sg, grp, sgens, gens );
             y :=[];
             for i in [1..Length(gens)] do
-               m := PreImagesRepresentative( h, n*gens[i]*n^-1 );
+               m := PreImagesRepresentativeNC( h, n*gens[i]*n^-1 );
                Append( y, m[d+1]{[1..d]}*n );
             od;
             y := StandardTranslation( y, nn );

--- a/init.g
+++ b/init.g
@@ -11,6 +11,11 @@
 ##                            GAP 4 Version
 ##
 
+##  introducing globally the NC version of PreImagesRepresentative 
+if not IsBound( PreImagesRepresentativeNC ) then 
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
+fi; 
+
 #############################################################################
 ##
 #R  read the declaration files


### PR DESCRIPTION
PreImagesRepresetnative, PreImages, PreImagesSet and PreImagesElm can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809. 
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions. 
The procedure to be adopted is as follows. 
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these.  PR #5073 addresses this. 
(2) Ask package authors/maintainers to convert all their calls to these functions to the NC versions (unless there is good reason not to do so). 
A clause added to init.g ensures the package works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations. 
This PR attempts to implement (2) for package cryst which only uses the first of these 4 operations.