### PR TITLE
Enhance the logic of SolveOneInhomEquationModZ to deal with case of no solution.

### DIFF
--- a/gap/wyckoff.gi
+++ b/gap/wyckoff.gi
@@ -287,8 +287,14 @@ end );
 ##                    {0, 1/a, ..., (a-1)/a} + b/a.
 ##  Note that 0 < b <  1, so 0 < b/a and (a-1)/a + b/a < 1.
 ##
+# According to the logic in SolutionMatMod1 function of fr package, 
+# this function should be enhanced as follows to deal with case of no solution:
 SolveOneInhomEquationModZ := function( a, b )
-    return [0..a-1] / a + b/a;
+    if a = 0 and FractionModOne(b) <> 0 then 
+      return []; # no solution
+    else
+      return [0..a-1] / a + b/a;
+    fi;
 end;
 
 #############################################################################


### PR DESCRIPTION
[`SolveOneInhomEquationModZ`](https://github.com/gap-packages/cryst/blob/f1a0f4fa54abe116d9ce3f08c76dda75e950fe3e/gap/wyckoff.gi#L280) doesn't have the logic to deal with the no solution case, as follows:

```gap
gap> M:=[ [ 0, 0, 0 ], [ 0, -2, 0 ], [ 0, 0, 0 ] ];
[ [ 0, 0, 0 ], [ 0, -2, 0 ], [ 0, 0, 0 ] ]
gap> b:= [ 1/2, 0, 0 ]  - [ 0, 0, 1/2 ];
[ 1/2, 0, -1/2 ]
gap> List( [ 1 .. Length( M ) ], i -> SolveOneInhomEquationModZ( M[i][i], b[i] ));
[ [  ], [  ], [  ] ]
```
This PR tries to tackle this problem according to the logic used in [`SolutionMatMod1`](https://github.com/gap-packages/fr/blob/43ad91bb349078e254372990da9f04162c99c379/gap/helpers.gi#L2022-L2051) function of `fr` package. 