### PR TITLE
Bug fixes in caching and comparison of Wyckoff positions

### DIFF
--- a/gap/cryst.gi
+++ b/gap/cryst.gi
@@ -291,7 +291,7 @@ function ( S, conj )
                       translation := w!.translation*c + t,
                       class       := w!.class,
                       spaceGroup  := R );
-            else # MODIFIED
+            else
               r := rec( basis       := w!.basis*c,
                       translation := w!.translation*c + t,
                       class       := w!.class,

--- a/gap/cryst.gi
+++ b/gap/cryst.gi
@@ -8,7 +8,6 @@
 ##
 ##  Methods for affine crystallographic groups
 ##
-## MODIFIED BY BERNARD FIELD (2023)
 
 #############################################################################
 ##

--- a/gap/cryst.gi
+++ b/gap/cryst.gi
@@ -285,17 +285,11 @@ function ( S, conj )
     if HasWyckoffPositions( S ) then
         W := [];
         for w in WyckoffPositions( S ) do
-            if w!.basis = [] then
-              r := rec( basis       := w!.basis,
-                      translation := w!.translation*c + t,
-                      class       := w!.class,
-                      spaceGroup  := R );
-            else
-              r := rec( basis       := w!.basis*c,
-                      translation := w!.translation*c + t,
-                      class       := w!.class,
-                      spaceGroup  := R );
-            fi;
+            r := rec( basis       := w!.basis,
+                    translation := w!.translation*c + t,
+                    class       := w!.class,
+                    spaceGroup  := R );
+            if r.basis <> [] then r.basis := r.basis * c; fi;
             ReduceAffineSubspaceLattice( r );
             Add( W, WyckoffPositionObject( r ) );
         od;
@@ -339,17 +333,11 @@ function ( S, conj )
     if HasWyckoffPositions( S ) then
         W := [];
         for w in WyckoffPositions( S ) do
-          if w!.basis = [] then
-            r := rec( basis       := w!.basis,
-                      translation := w!.translation*c + t,
-                      class       := w!.class,
-                      spaceGroup  := R );
-          else
-            r := rec( basis       := w!.basis*c,
-                      translation := w!.translation*c + t,
-                      class       := w!.class,
-                      spaceGroup  := R );
-          fi;
+          r := rec( basis       := w!.basis,
+                    translation := w!.translation*c + t,
+                    class       := w!.class,
+                    spaceGroup  := R );
+          if r.basis <> [] then r.basis := r.basis * c; fi;
           ReduceAffineSubspaceLattice( r );
           Add( W, WyckoffPositionObject( r ) );
         od;

--- a/gap/cryst.gi
+++ b/gap/cryst.gi
@@ -8,6 +8,7 @@
 ##
 ##  Methods for affine crystallographic groups
 ##
+## MODIFIED BY BERNARD FIELD (2023)
 
 #############################################################################
 ##
@@ -256,7 +257,7 @@ InstallOtherMethod( \^,
     IsCollsElms, [ IsAffineCrystGroupOnRight, IsMatrix ], 0,
 function ( S, conj )
 
-    local d, c, C, Ci, gens, i, R, W, r, w;
+    local d, c, C, Ci, gens, i, R, W, r, w, t;
 
     d := DimensionOfMatrixGroup( S ) - 1;
     if not IsAffineMatrixOnRight( conj ) then
@@ -267,6 +268,7 @@ function ( S, conj )
     C  := conj;
     Ci := conj^-1;
     c  := C {[1..d]}{[1..d]};
+    t  := C [d+1]{[1..d]}; # Translation
 
     # conjugate the generators of S
     gens := ShallowCopy( GeneratorsOfGroup( S ) );
@@ -284,10 +286,17 @@ function ( S, conj )
     if HasWyckoffPositions( S ) then
         W := [];
         for w in WyckoffPositions( S ) do
-            r := rec( basis       := w!.basis*c,
-                      translation := w!.translation*c,
+            if w!.basis = [] then
+              r := rec( basis       := w!.basis,
+                      translation := w!.translation*c + t,
                       class       := w!.class,
                       spaceGroup  := R );
+            else # MODIFIED
+              r := rec( basis       := w!.basis*c,
+                      translation := w!.translation*c + t,
+                      class       := w!.class,
+                      spaceGroup  := R );
+            fi;
             ReduceAffineSubspaceLattice( r );
             Add( W, WyckoffPositionObject( r ) );
         od;
@@ -302,7 +311,7 @@ InstallOtherMethod( \^,
     IsCollsElms, [ IsAffineCrystGroupOnLeft, IsMatrix ], 0,
 function ( S, conj )
 
-    local d, c, C, Ci, gens, i, R, W, r, w;
+    local d, c, C, Ci, gens, i, R, W, r, w, t;
 
     d := DimensionOfMatrixGroup( S ) - 1;
     if not IsAffineMatrixOnLeft( conj ) then
@@ -313,6 +322,7 @@ function ( S, conj )
     C  := conj;
     Ci := conj^-1;
     c  := TransposedMat( C {[1..d]}{[1..d]} );
+    t  := C {[1..d]}[d+1]; # Translation
 
     # conjugate the generators of S
     gens := ShallowCopy( GeneratorsOfGroup( S ) );
@@ -330,12 +340,19 @@ function ( S, conj )
     if HasWyckoffPositions( S ) then
         W := [];
         for w in WyckoffPositions( S ) do
-            r := rec( basis       := w!.basis*c,
-                      translation := w!.translation*c,
+          if w!.basis = [] then
+            r := rec( basis       := w!.basis,
+                      translation := w!.translation*c + t,
                       class       := w!.class,
                       spaceGroup  := R );
-            ReduceAffineSubspaceLattice( r );
-            Add( W, WyckoffPositionObject( r ) );
+          else
+            r := rec( basis       := w!.basis*c,
+                      translation := w!.translation*c + t,
+                      class       := w!.class,
+                      spaceGroup  := R );
+          fi;
+          ReduceAffineSubspaceLattice( r );
+          Add( W, WyckoffPositionObject( r ) );
         od;
         SetWyckoffPositions( R, W );
     fi;

--- a/gap/wyckoff.gi
+++ b/gap/wyckoff.gi
@@ -117,7 +117,6 @@ end );
 ##
 InstallGlobalFunction( ImageAffineSubspaceLattice, function( s, g )
     local d, m, t, b, r;
-    if IsAffineMatrixOnLeft(g) then g := TransposedMat(g); fi;
     d := Length( s.translation );
     m := g{[1..d]}{[1..d]};
     t := g[d+1]{[1..d]};
@@ -137,7 +136,6 @@ end );
 ##
 InstallGlobalFunction( ImageAffineSubspaceLatticePointwise, function( s, g )
     local d, m, t, b, L, r;
-    if IsAffineMatrixOnLeft(g) then g := TransposedMat(g); fi;
     d := Length( s.translation );
     m := g{[1..d]}{[1..d]};
     t := g[d+1]{[1..d]};
@@ -174,6 +172,9 @@ function( w1, w2 )
     gens := Filtered( GeneratorsOfGroup( S ),
                       x -> x{[1..d]}{[1..d]} <> One( PointGroup( S ) ) );
     U := SubgroupNC( S, gens );
+    if IsAffineCrystGroupOnLeft( U ) then
+      U := TransposedMatrixGroup( U );
+    fi;
     rep := RepresentativeAction( U, r1, r2, ImageAffineSubspaceLattice );
     return rep <> fail;
 end );
@@ -202,6 +203,9 @@ function( w1, w2 )
     gens := Filtered( GeneratorsOfGroup( S ),
                       x -> x{[1..d]}{[1..d]} <> One( PointGroup( S ) ) );
     U := SubgroupNC( S, gens );
+    if IsAffineCrystGroupOnLeft( U ) then
+      U := TransposedMatrixGroup( U );
+    fi;
     o1 := Orbit( U, r1, ImageAffineSubspaceLattice );
     o2 := Orbit( U, r2, ImageAffineSubspaceLattice );
     o1 := Set( List( o1, x -> rec( t := x.translation, b := x.basis ) ) );

--- a/gap/wyckoff.gi
+++ b/gap/wyckoff.gi
@@ -117,6 +117,7 @@ end );
 ##
 InstallGlobalFunction( ImageAffineSubspaceLattice, function( s, g )
     local d, m, t, b, r;
+    if IsAffineMatrixOnLeft(g) then g := TransposedMat(g); fi;
     d := Length( s.translation );
     m := g{[1..d]}{[1..d]};
     t := g[d+1]{[1..d]};
@@ -136,6 +137,7 @@ end );
 ##
 InstallGlobalFunction( ImageAffineSubspaceLatticePointwise, function( s, g )
     local d, m, t, b, L, r;
+    if IsAffineMatrixOnLeft(g) then g := TransposedMat(g); fi;
     d := Length( s.translation );
     m := g{[1..d]}{[1..d]};
     t := g[d+1]{[1..d]};

--- a/tst/cryst.tst
+++ b/tst/cryst.tst
@@ -177,12 +177,17 @@ false
 
 gap> G := SpaceGroupIT(3,183);;
 gap> W := WyckoffPositions(G);;
+gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 0, 0, 0, 1 ] ];;
+gap> IsSpaceGroup( G^C );
+true
+
+# the next check verifies that problem BLAH BLAH BLAH is gone
 gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 1/2, 0, 0, 1 ] ];;
 gap> IsSpaceGroup( G^C );
 true
 
 # Test that caching of Wyckoff followed by conjugation works as expected
-# I use Set because the order of the Wyckoff Positions is semi-arbitrary.
+# Use Set because the order of the Wyckoff positions is semi-arbitrary.
 gap> Set(WyckoffPositions( G^C )) = Set(WyckoffPositions(SpaceGroupIT(3,183)^C));
 true
 
@@ -195,7 +200,7 @@ true
 gap> Set(WyckoffPositions( G^TransposedMat(C) )) = Set(WyckoffPositions(SpaceGroupOnLeftIT(3,183)^TransposedMat(C)));
 true
 
-# Test with a Wyckoff positions that has empty basis.
+# Test Wyckoff positions in a case that involves an empty basis (see <https://github.com/gap-packages/cryst/issues/42>).
 gap> G := SpaceGroupIT( 3, 12 );;
 gap> W := WyckoffPositions(G);;
 gap> IsSpaceGroup( G^C );

--- a/tst/cryst.tst
+++ b/tst/cryst.tst
@@ -177,14 +177,25 @@ false
 
 gap> G := SpaceGroupIT(3,183);;
 gap> W := WyckoffPositions(G);;
-gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 0, 0, 0, 1 ] ];;
+gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 1/2, 0, 0, 1 ] ];;
 gap> IsSpaceGroup( G^C );
+true
+
+# Test that caching of Wyckoff followed by conjugation works as expected
+# I use Set because the order of the Wyckoff Positions is semi-arbitrary.
+gap> Set(WyckoffPositions( G^C )) = Set(WyckoffPositions(SpaceGroupIT(3,183)^C));
 true
 
 gap> G := TransposedMatrixGroup( G );
 <matrix group with 6 generators>
 gap> W := WyckoffPositions(G);;
 gap> IsSpaceGroup( G^TransposedMat(C) );
+true
+
+# Test with a Wyckoff positions that has empty basis.
+gap> G := SpaceGroupIT( 3, 12 );;
+gap> W := WyckoffPositions(G);;
+gap> IsSpaceGroup( G^C );
 true
 
 gap> G := SpaceGroupIT( 3, 208 );

--- a/tst/cryst.tst
+++ b/tst/cryst.tst
@@ -181,7 +181,8 @@ gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 0, 0, 0, 1 ] ];;
 gap> IsSpaceGroup( G^C );
 true
 
-# the next check verifies that problem BLAH BLAH BLAH is gone
+# The next checks verify that including a translation component in conjugation
+# works correctly, as from <https://github.com/gap-packages/cryst/issues/44>.
 gap> C := [ [ 3, 1, 0, 0 ], [ -1, -2, 0, 0 ], [ 2, 0, 1, 0 ], [ 1/2, 0, 0, 1 ] ];;
 gap> IsSpaceGroup( G^C );
 true

--- a/tst/cryst.tst
+++ b/tst/cryst.tst
@@ -192,6 +192,9 @@ gap> W := WyckoffPositions(G);;
 gap> IsSpaceGroup( G^TransposedMat(C) );
 true
 
+gap> Set(WyckoffPositions( G^TransposedMat(C) )) = Set(WyckoffPositions(SpaceGroupOnLeftIT(3,183)^TransposedMat(C)));
+true
+
 # Test with a Wyckoff positions that has empty basis.
 gap> G := SpaceGroupIT( 3, 12 );;
 gap> W := WyckoffPositions(G);;


### PR DESCRIPTION
Fixes for issues https://github.com/gap-packages/cryst/issues/42 and https://github.com/gap-packages/cryst/issues/44 .
Tests for the fixes.

In testing, I came across another bug, where comparison of certain LeftAction WyckoffPositions (with complicated conjugations) would raise errors about rationals being where integers were expected. I traced this down to ImageAffineSubspaceLattice not handling the case of left-acting affine matrices (instead treating them as if they were right-acting).