### PR TITLE
Fix tests against latest GAP master

### DIFF
--- a/doc/cryst.tex
+++ b/doc/cryst.tex
@@ -359,25 +359,20 @@ is bound and `true'.
 \beginexample
 gap> S := SpaceGroupIT(3,222);
 SpaceGroupOnRightIT(3,222,'2')
-gap> L := MaximalSubgroupClassReps( S, rec( primes := [3,5] ) );
-[ <matrix group with 7 generators>, <matrix group with 8 generators>, 
-  <matrix group with 8 generators> ]
+gap> L := MaximalSubgroupClassReps( S, rec( primes := [3,5] ) );;
 gap> List( L, IndexInParent );
 [ 3, 27, 125 ]
 gap> L := MaximalSubgroupClassReps( S,             
->                  rec( classequal := true, primes := [3,5] ) );
-[ <matrix group with 8 generators>, <matrix group with 8 generators> ]
+>                  rec( classequal := true, primes := [3,5] ) );;
 gap> List( L, IndexInParent );                                                 
 [ 27, 125 ]
 gap> L := MaximalSubgroupClassReps( S,
->                  rec( latticeequal := true, primes := [3,5] ) );
-[ <matrix group with 7 generators> ]
+>                  rec( latticeequal := true, primes := [3,5] ) );;
 gap> List( L, IndexInParent );                                       
 [ 3 ]
-gap> L := MaximalSubgroupClassReps( S, rec( latticeequal := true ) );
-[ <matrix group with 7 generators>, <matrix group with 7 generators>, 
-  <matrix group with 7 generators>, <matrix group with 7 generators>, 
-  <matrix group with 6 generators> ]
+gap> L := MaximalSubgroupClassReps( S, rec( latticeequal := true ) );;
+gap> Length(L);
+5
 gap> List( L, IndexInParent );                                       
 [ 2, 2, 2, 3, 4 ]
 \endexample

--- a/tst/crystcat.tst
+++ b/tst/crystcat.tst
@@ -34,8 +34,7 @@ gap> Size( cl[1] );
 gap> G := SpaceGroupBBNWZ( 4, 29, 7, 2, 1 );
 SpaceGroupOnRightBBNWZ( 4, 29, 7, 2, 1 )
 
-gap> H := MaximalSubgroupRepsTG( G )[4];
-<matrix group with 7 generators>
+gap> H := MaximalSubgroupRepsTG( G )[4];;
 
 gap> C := ColorGroup( G, H );
 <matrix group with 8 generators>

--- a/tst/manual.tst
+++ b/tst/manual.tst
@@ -5,31 +5,26 @@ gap> SetAssertionLevel(1);
 gap> S := SpaceGroupIT(3,222);
 SpaceGroupOnRightIT(3,222,'2')
 
-gap> L := MaximalSubgroupClassReps( S, rec( primes := [3,5] ) );
-[ <matrix group with 7 generators>, <matrix group with 8 generators>, 
-  <matrix group with 8 generators> ]
+gap> L := MaximalSubgroupClassReps( S, rec( primes := [3,5] ) );;
 
 gap> List( L, IndexInParent );
 [ 3, 27, 125 ]
 
 gap> L := MaximalSubgroupClassReps( S,             
->                  rec( classequal := true, primes := [3,5] ) );
-[ <matrix group with 8 generators>, <matrix group with 8 generators> ]
+>                  rec( classequal := true, primes := [3,5] ) );;
 
 gap> List( L, IndexInParent );                                                 
 [ 27, 125 ]
 
 gap> L := MaximalSubgroupClassReps( S,
->                  rec( latticeequal := true, primes := [3,5] ) );
-[ <matrix group with 7 generators> ]
+>                  rec( latticeequal := true, primes := [3,5] ) );;
 
 gap> List( L, IndexInParent );                                       
 [ 3 ]
 
-gap> L := MaximalSubgroupClassReps( S, rec( latticeequal := true ) );
-[ <matrix group with 7 generators>, <matrix group with 7 generators>, 
-  <matrix group with 7 generators>, <matrix group with 7 generators>, 
-  <matrix group with 6 generators> ]
+gap> L := MaximalSubgroupClassReps( S, rec( latticeequal := true ) );;
+gap> Length(L);
+5
 
 gap> List( L, IndexInParent );                                       
 [ 2, 2, 2, 3, 4 ]


### PR DESCRIPTION
Some maximal subgroups now are computed with fewer generators...
