### PR TITLE
Fix `WyckoffPositions` to work with next GAP release

### DIFF
--- a/gap/wyckoff.gi
+++ b/gap/wyckoff.gi
@@ -596,7 +596,7 @@ WyPosAT := function( S )
 
     zz := []; mat := []; vec := [];
     for g in Zuppos( NiceObject( P ) ) do
-        if g <> () then
+        if not IsOne(g) then
             m := NiceToCrystStdRep(P,g);
             if IsAffineCrystGroupOnRight( S ) then
                 m := TransposedMat(m);
@@ -627,7 +627,7 @@ WyPosAT := function( S )
     lst.W := List( [1..d+1], x -> [] ); Add( lst.W[d+1], w );
 
     if 1 <= Length(lst.z) then
-        WyPosStep(1,TrivialGroup(IsPermGroup),[],[],lst);
+        WyPosStep(1,TrivialSubgroup(NiceObject( P )),[],[],lst);
     fi;
 
     return Flat(lst.W);


### PR DESCRIPTION
The code was making assumptions about how nice objects of integer matrix groups might look like, which never were warranted, and with the current GAP development version are violated (as we improved the code for rational matrix groups massively, see https://github.com/gap-system/gap/pull/6008). Luckily the fix is easy and is contained in this PR.

Unfortunately this affects the output of some tests: the order of the entries in the list returned by `WyckoffPositions` is changed. I tried dealing with that by adjusting the tests to sort the output before printing it. But that's not quite enough, as in e.g. `Wyckoff position, point group 3, translation ...` it changes from `point group 3` to something else, e.g. `point group 2`. I am not sure what the numbering means; is it meant to be universal (i.e. there is another bug here), or is it expected that it depends on the order in which e.g. elements of the group are enumerated, and thus the change is "OK" ? (This still leaves the question how to modify the .tst file so that this works in all supported GAP versions; I'd be happy to figure that out but of course it would be good to first know whether this is actually OK...)

CC @beick @gaehler 