### PR TITLE
Make tests pass in GAP master

### DIFF
--- a/tst/cryst.tst
+++ b/tst/cryst.tst
@@ -23,6 +23,32 @@ gap> NormalizerInGLnZ( P );
 gap> G := SpaceGroupIT(3,68);
 SpaceGroupOnRightIT(3,68,'2')
 
+#@if CompareVersionNumbers(GAPInfo.Version, "4.15")
+gap> pos := SortedList(WyckoffPositions(G));
+[ < Wyckoff position, point group 6, translation := [ 0, 0, 1/2 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 3, translation := [ 0, 1/4, 1/4 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 3, translation := [ 0, 1/4, 3/4 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 6, translation := [ 1/4, 1/4, 1/2 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 5, translation := [ 0, 3/4, 0 ],
+    basis := [ [ 0, 0, 1 ] ] >
+    , < Wyckoff position, point group 5, translation := [ 1/4, 0, 0 ],
+    basis := [ [ 0, 0, 1 ] ] >
+    , < Wyckoff position, point group 4, translation := [ 0, 0, 1/4 ],
+    basis := [ [ 0, 1, 0 ] ] >
+    , < Wyckoff position, point group 1, translation := [ 0, 0, 0 ],
+    basis := [ [ 1/2, 1/2, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ] >
+    , < Wyckoff position, point group 2, translation := [ 1/4, 1/4, 1/4 ],
+    basis := [ [ 1, 0, 0 ] ] >
+     ]
+
+gap> WyckoffStabilizer(pos[6]);
+Group(
+[ [ [ -1, 0, 0, 0 ], [ 0, -1, 0, 0 ], [ 0, 0, 1, 0 ], [ 1/2, 0, 0, 1 ] ] ])
+#@else
 gap> pos := WyckoffPositions(G);
 [ < Wyckoff position, point group 3, translation := [ 0, 3/4, 1/4 ], 
     basis := [  ] >
@@ -47,6 +73,7 @@ gap> pos := WyckoffPositions(G);
 gap> WyckoffStabilizer(pos[5]);
 Group(
 [ [ [ -1, 0, 0, 0 ], [ 0, -1, 0, 0 ], [ 0, 0, 1, 0 ], [ 1/2, 0, 0, 1 ] ] ])
+#@fi
 
 gap> S := SpaceGroupIT(2,7);
 SpaceGroupOnRightIT(2,7,'1')

--- a/tst/manual.tst
+++ b/tst/manual.tst
@@ -67,6 +67,20 @@ gap> if IsPackageMarkedForLoading( "CaratInterface", "" ) then
 gap> S := SpaceGroupIT(2,14);
 SpaceGroupOnRightIT(2,14,'1')
 
+#@if CompareVersionNumbers(GAPInfo.Version, "4.15")
+gap> W := WyckoffPositions(S);
+[ < Wyckoff position, point group 2, translation := [ 0, 0 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 2, translation := [ 2/3, 1/3 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 2, translation := [ 1/3, 2/3 ],
+    basis := [  ] >
+    , < Wyckoff position, point group 3, translation := [ 0, 0 ],
+    basis := [ [ 1, -1 ] ] >
+    , < Wyckoff position, point group 1, translation := [ 0, 0 ],
+    basis := [ [ 1, 0 ], [ 0, 1 ] ] >
+     ]
+#@else
 gap> W := WyckoffPositions(S);
 [ < Wyckoff position, point group 3, translation := [ 0, 0 ], 
     basis := [  ] >
@@ -79,6 +93,7 @@ gap> W := WyckoffPositions(S);
     , < Wyckoff position, point group 1, translation := [ 0, 0 ], 
     basis := [ [ 1, 0 ], [ 0, 1 ] ] >
      ]
+#@fi
 
 gap> sub := Group([ [ [ 0, -1 ], [ -1, 0 ] ] ]);
 Group([ [ [ 0, -1 ], [ -1, 0 ] ] ])
@@ -109,6 +124,20 @@ Group([ [ [ 0, -1, 0 ], [ -1, 0, 0 ], [ 0, 0, 1 ] ] ])
 gap> IsAffineCrystGroupOnRight( stab );
 true
 
+#@if CompareVersionNumbers(GAPInfo.Version, "4.15")
+gap> orb := WyckoffOrbit( W[4] );
+[ < Wyckoff position, point group 3, translation := [ 0, 0 ],
+    basis := [ [ 1, -1 ] ] >
+    , < Wyckoff position, point group 3, translation := [ 0, 0 ],
+    basis := [ [ 1, 2 ] ] >
+    , < Wyckoff position, point group 3, translation := [ 0, 0 ],
+    basis := [ [ -2, -1 ] ] >
+     ]
+gap> Set(orb);
+[ < Wyckoff position, point group 3, translation := [ 0, 0 ],
+    basis := [ [ 1, -1 ] ] >
+     ]
+#@else
 gap> orb := WyckoffOrbit( W[4] );
 [ < Wyckoff position, point group 2, translation := [ 0, 0 ], 
     basis := [ [ 1, -1 ] ] >
@@ -121,6 +150,7 @@ gap> Set(orb);
 [ < Wyckoff position, point group 2, translation := [ 0, 0 ], 
     basis := [ [ 1, -1 ] ] >
      ]
+#@fi
 
 gap> G := Group(  (1,2,3), (2,3,4) );
 Group([ (1,2,3), (2,3,4) ])


### PR DESCRIPTION
@gaehler that's one way to have the tests pass in multiple GAP versions. That said, someone should verify that the new outputs really are OK -- they differ in more than just the point group numbering, also the "translation" entries are different. But I hope this is just a matter of choice of representatives?

If this works for you, it would be great if you could make a fresh release of `cryst` soon so that the GAP package test suite is un-broken :-)