### PR TITLE
etc/make_tar: ensure refs to GAP manual are relative

### DIFF
--- a/etc/make_tar
+++ b/etc/make_tar
@@ -5,8 +5,8 @@ PKGTAR=cryst-4.1.32.tar
 # remove old archive
 rm -f $PKGTAR*
 
-# rebuild documentation
-(cd .. && gap -A -q --quitonbreak makedoc.g)
+# update documentation
+(cd .. && gap -A -q --quitonbreak -c 'Read("makedoc.g" : relativePath:="../../..");')
 
 # make the package archive
 mkdir -p cryst/doc cryst/gap cryst/grp cryst/tst


### PR DESCRIPTION
This PR mirrors https://github.com/gap-packages/crystcat/pull/21 and https://github.com/gap-packages/CaratInterface/pull/43 -- however, since there is no reference to the GAP reference manual in the `cryst` manual, it actually updated just fine. So this is more of a proactive change to prevent future issues.